### PR TITLE
Package Mastermind to Flatpak

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/artwork-fix-icon.patch
+++ b/artwork-fix-icon.patch
@@ -1,0 +1,29 @@
+From 24a68f77594bd4b974953cb727117953ff24e3b9 Mon Sep 17 00:00:00 2001
+From: Martin Abente Lahaye <tch@sugarlabs.org>
+Date: Wed, 30 Oct 2019 10:09:22 -0300
+Subject: [PATCH] Don't override existing document-open icon
+
+Remove this old override on a existing icon. Otherwise
+the document-open icon is shown as actvity-start.
+
+Looking at b8a1f426, it is clear that this override was
+added before we provided our own version of this icon.
+---
+ icons/scalable/actions/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/icons/scalable/actions/Makefile.am b/icons/scalable/actions/Makefile.am
+index 94fd6f0..729c86e 100755
+--- a/icons/scalable/actions/Makefile.am
++++ b/icons/scalable/actions/Makefile.am
+@@ -134,7 +134,6 @@ EXTRA_DIST = $(icon_DATA)
+ # install aliases for icons, and the use the icon-naming-utils to install
+ # further aliases for compatibility with gtk stock icon names.
+ install-data-local: install-iconDATA
+-	ln -sf activity-start.svg $(DESTDIR)$(icondir)/document-open.svg
+ 	ln -sf activity-stop.svg $(DESTDIR)$(icondir)/application-exit.svg
+ 	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/dialog-apply.svg
+ 	ln -sf dialog-ok.svg $(DESTDIR)$(icondir)/gtk-ok.svg
+-- 
+2.19.1
+

--- a/artwork-nogtk2.patch
+++ b/artwork-nogtk2.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile.am b/Makefile.am
+index ea51bb2..69c9f33 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1 +1 @@
+-SUBDIRS = cursor icons gtk gtk3
++SUBDIRS = cursor icons gtk3
+diff --git a/configure.ac b/configure.ac
+index 82c7654..4c6edd2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,18 +26,11 @@ if test -z "$EMPY"; then
+     AC_MSG_ERROR([empy is required])
+ fi
+ 
+-PKG_CHECK_MODULES(GTK2, gtk+-2.0 >= 2.16.0,,
+-	          AC_MSG_ERROR([GTK+-2.0 is required to compile sugar-artwork]))
+-
+ PKG_CHECK_MODULES(GTK3, gtk+-3.0 >= 3.0.0,,
+ 	          AC_MSG_ERROR([GTK+-3.0 is required to compile sugar-artwork]))
+ 
+-PKG_CHECK_MODULES(ENGINE, gtk+-2.0 >= 2.16 gobject-2.0 >= 2.0 cairo >= 0.1.1)
+ PKG_CHECK_MODULES(ENGINE3, gtk+-3.0 >= 3.0 gobject-2.0 >= 2.0 cairo >= 0.1.1)
+ 
+-GTK_VERSION=`$PKG_CONFIG --variable=gtk_binary_version gtk+-2.0`
+-AC_SUBST(GTK_VERSION)
+-
+ GTK3_VERSION=`$PKG_CONFIG --modversion gtk+-3.0`
+ AC_SUBST(GTK3_VERSION)
+ 
+@@ -72,9 +65,6 @@ icons/scalable/device/Makefile
+ icons/scalable/emblems/Makefile
+ icons/scalable/mimetypes/Makefile
+ icons/scalable/status/Makefile
+-gtk/Makefile
+-gtk/engine/Makefile
+-gtk/theme/Makefile
+ gtk3/Makefile
+ gtk3/theme/Makefile
+ gtk3/theme/3.20/Makefile

--- a/mastermind-info.patch
+++ b/mastermind-info.patch
@@ -1,0 +1,24 @@
+diff --git a/activity/activity.info b/activity/activity.info
+index ae1317b..d6b416c 100644
+--- a/activity/activity.info
++++ b/activity/activity.info
+@@ -1,6 +1,18 @@
+ [Activity]
+ name = Mastermind
+-bundle_id = org.laptop.Mastermind
++bundle_id = org.sugarlabs.Mastermind
+ icon = icon
+ exec = sugar-activity3 activity.Mastermind
+ activity_version = 1
++release_date = 2020-01-20
++metadata_license = CC0-1.0
++license = GPLv3+
++summary = Mastermind game for Sugar.
++description = Mastermind game for Sugar! Drag and drop the colors in correct places for win. 
++repository = https://github.com/sugarlabs/mastermind-activity
++url = https://github.com/sugarlabs/mastermind-activity
++category = Game
++tags = Game
++update_contact = tch@sugarlabs.org
++developer_name = Sugar Labs Community
++screenshots = http://activities.sugarlabs.org/en-US/sugar/images/p/1290/1484276276.png

--- a/mastermind-monitors.patch
+++ b/mastermind-monitors.patch
@@ -1,0 +1,46 @@
+diff --git a/constants.py b/constants.py
+index 6253f38..0ba9986 100644
+--- a/constants.py
++++ b/constants.py
+@@ -26,6 +26,7 @@ gi.require_version("Gtk", "3.0")
+ from gi.repository import Gtk
+ from gi.repository import Gdk
+ 
++from sugarapp.helpers import PrimaryMonitor
+ 
+ LOCAL_DIR = os.path.dirname(os.path.realpath(__file__))
+ 
+@@ -33,7 +34,7 @@ DRAG_TARGETS = [Gtk.TargetEntry.new("BALL", Gtk.TargetFlags.SAME_APP, 0)]
+ IGNORE_TARGETS = []
+ DRAG_ACTION = Gdk.DragAction.MOVE
+ 
+-BALL_SIZE = (Gdk.Screen.height() - 200) / 10
++BALL_SIZE = (PrimaryMonitor.height() - 200) / 10
+ 
+ 
+ class BallType:
+diff --git a/helpbutton.py b/helpbutton.py
+index 74450ef..4672970 100644
+--- a/helpbutton.py
++++ b/helpbutton.py
+@@ -28,6 +28,7 @@ from gi.repository import Gdk
+ 
+ from sugar3.graphics.toolbutton import ToolButton
+ 
++from sugarapp.helpers import PrimaryMonitor
+ 
+ class HelpButton(Gtk.ToolItem):
+ 
+@@ -41,10 +42,10 @@ class HelpButton(Gtk.ToolItem):
+         self._palette = help_button.get_palette()
+ 
+         sw = Gtk.ScrolledWindow()
+-        sw.set_size_request(int(Gdk.Screen.width() / 2.8), 310)
++        sw.set_size_request(int(PrimaryMonitor.width() / 2.8), 310)
+         sw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+ 
+-        self._max_text_width = int(Gdk.Screen.width() / 3) - 600
++        self._max_text_width = int(PrimaryMonitor.width() / 3) - 600
+         self._vbox = Gtk.Box()
+         self._vbox.set_orientation(Gtk.Orientation.VERTICAL)
+         self._vbox.set_homogeneous(False)

--- a/mastermind-port.patch
+++ b/mastermind-port.patch
@@ -1,0 +1,92 @@
+diff --git a/activity.py b/activity.py
+index e8234dc..000e6bc 100644
+--- a/activity.py
++++ b/activity.py
+@@ -26,6 +26,7 @@ from constants import BallType
+ from helpbutton import HelpButton
+ 
+ import gi
++import json
+ gi.require_version("Gtk", "3.0")
+ 
+ from gi.repository import Gtk
+@@ -33,16 +34,16 @@ from gi.repository import Pango
+ 
+ from sugar3.graphics.toolbutton import ToolButton
+ from sugar3.graphics.toolbarbox import ToolbarBox
+-
+-from sugar3.activity.widgets import ActivityToolbarButton
+ from sugar3.activity.widgets import StopButton
+-from sugar3.activity import activity
++
++from sugarapp.widgets import SugarCompatibleActivity
++from sugarapp.widgets import ExtendedActivityToolbarButton
+ 
+ 
+-class Mastermind(activity.Activity):
++class Mastermind(SugarCompatibleActivity):
+ 
+     def __init__(self, handle):
+-        activity.Activity.__init__(self, handle)
++        SugarCompatibleActivity.__init__(self, handle)
+ 
+         self.canvas = Canvas()
+         self.canvas.connect("data-changed", self._data_changed_cb)
+@@ -51,7 +52,6 @@ class Mastermind(activity.Activity):
+         self.set_canvas(self.canvas)
+ 
+         self.make_toolbar()
+-        self.read_file()
+ 
+         self.show_all()
+ 
+@@ -66,7 +66,7 @@ class Mastermind(activity.Activity):
+         self.set_toolbar_box(toolbarbox)
+ 
+         toolbar = toolbarbox.toolbar
+-        toolbar.insert(ActivityToolbarButton(self), -1)
++        toolbar.insert(ExtendedActivityToolbarButton(self), -1)
+         toolbar.insert(make_separator(False), -1)
+ 
+         self.restart_button = ToolButton(icon_name="system-restart")
+@@ -106,15 +106,19 @@ class Mastermind(activity.Activity):
+ 
+         toolbar.show_all()
+ 
+-    def read_file(self):
+-        if "level" in list(self.metadata.keys()):
++    def read_file(self, path):
++        with open(path, 'r') as save_file:
++            data = save_file.read()
++            metadata = json.loads(data)
++
++        if "level" in list(metadata.keys()):
+             data = {
+-                "level": int(self.metadata["level"]),
+-                "correct": [int(x) for x in eval(self.metadata["correct"])],
++                "level": int(metadata["level"]),
++                "correct": [int(x) for x in eval(metadata["correct"])],
+                 "balls": {}
+             }
+ 
+-            balls = eval(self.metadata["balls"])
++            balls = eval(metadata["balls"])
+             for key in balls:
+                 x = int(key)
+                 data["balls"][x] = []
+@@ -132,9 +136,12 @@ class Mastermind(activity.Activity):
+ 
+     def write_file(self, path):
+         data = self.canvas.get_game_data()
+-        self.metadata["level"] = str(data["level"]).encode('utf-8')
+-        self.metadata["correct"] = str(data["correct"]).encode('utf-8')
+-        self.metadata["balls"] = str(data["balls"]).encode('utf-8')
++        metadata = {}
++        metadata["level"] = str(data["level"]).encode('utf-8')
++        metadata["correct"] = str(data["correct"]).encode('utf-8')
++        metadata["balls"] = str(data["balls"]).encode('utf-8')
++        with open(path, 'w') as save_file:
++            save_file.write(json.dumps(metadata))
+ 
+     def _ok_cb(self, button):
+         self.canvas.end_turn()

--- a/org.sugarlabs.MastermindActivity.json
+++ b/org.sugarlabs.MastermindActivity.json
@@ -1,0 +1,222 @@
+{
+    "app-id": "org.sugarlabs.MastermindActivity",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.34",
+    "sdk": "org.gnome.Sdk",
+    "separate-locales": false,
+    "command": "sugarapp",
+    "finish-args": [
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--share=ipc",
+        "--device=dri",
+        "--env=SUGAR_BUNDLE_ID=org.sugarlabs.MastermindActivity",
+        "--env=SUGAR_BUNDLE_PATH=/app/share/sugar/activities/Mastermind.activity/"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/aclocal",
+        "/share/info",
+        "/share/man"
+    ],
+    "modules": [
+        "shared-modules/dbus-glib/dbus-glib-0.110.json",
+        "shared-modules/intltool/intltool-0.51.json",
+        {
+            "name": "empy",
+            "cleanup": ["*"],
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} empy"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/3b/95/88ed47cb7da88569a78b7d6fb9420298df7e99997810c844a924d96d3c08/empy-3.3.4.tar.gz",
+                "sha256": "73ac49785b601479df4ea18a7c79bc1304a8a7c34c02b9472cf1206ae88f01b3"
+            }],
+            "post-install": [
+                "chmod +x /app/lib/python3.7/site-packages/em.py",
+                "mkdir -p /app/bin/",
+                "ln -s /app/lib/python3.7/site-packages/em.py /app/bin/empy"
+            ]
+        },
+        {
+            "name": "perl-XML-Simple",
+            "cleanup": ["*"],
+            "no-autogen": true,
+            "build-options": {
+                "no-debuginfo": true
+            },
+            "sources": [{
+                    "type": "archive",
+                    "url": "https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz",
+                    "sha256": "531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8"
+                },
+                {
+                    "type": "file",
+                    "path": "perl-MakefilePL-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name": "xcursorgen",
+            "cleanup": ["*"],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/freedesktop/xcursorgen/archive/xcursorgen-1.0.6.tar.gz",
+                "sha256": "0566c6848c93ef092b37e4ffdc6e86e9249fa9721f663117787b6cefea5eb55b"
+            }]
+        },
+        {
+            "name": "icon-naming-utils",
+            "cleanup": ["*"],
+            "build-options": {
+                "env": {
+                    "PERL5LIB": "/app/lib/perl5/site_perl/5.30.0/"
+                }
+            },
+            "sources": [{
+                "type": "archive",
+                "url": "http://tango.freedesktop.org/releases/icon-naming-utils-0.8.90.tar.gz",
+                "sha256": "044ab2199ed8c6a55ce36fd4fcd8b8021a5e21f5bab028c0a7cdcf52a5902e1c"
+            }]
+        },
+        {
+            "name": "sugar-artwork",
+            "no-parallel-make": true,
+            "build-options": {
+                "env": {
+                    "PERL5LIB": "/app/lib/perl5/site_perl/5.30.0/"
+                }
+            },
+            "sources": [{
+                    "type": "git",
+                    "url": "https://github.com/sugarlabs/sugar-artwork.git",
+                    "tag": "v0.116",
+                    "commit": "7a5226bba79527efa5162562fa2f2f8db4fa326a"
+                },
+                {
+                    "type": "patch",
+                    "path": "artwork-fix-icon.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "artwork-nogtk2.patch"
+                }
+            ]
+        },
+        {
+            "name": "python-dbus",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" dbus-python"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/b6/85/7b46d31f15a970665533ad5956adee013f03f0ad4421c3c83304ae9c9906/dbus-python-1.2.12.tar.gz",
+                "sha256": "cdd4de2c4f5e58f287b12013ed7b41dee81d503c8d0d2397c5bd2fb01badf260"
+            }]
+        },
+        {
+            "name": "decorator",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" decorator"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://pypi.python.org/packages/70/f1/cb9373195639db13063f55eb06116310ad691e1fd125e6af057734dc44ea/decorator-4.2.1.tar.gz",
+                "sha256": "7d46dd9f3ea1cf5f06ee0e4e1277ae618cf48dfb10ada7c8427cd46c42702a0e"
+            }]
+        },
+        {
+            "name": "python-six",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" six"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz",
+                "sha256": "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            }]
+        },
+        {
+            "name": "telepathy-glib",
+            "config-opts": ["--disable-static", "--disable-gtk-doc"],
+            "sources": [{
+                    "type": "git",
+                    "url": "https://www.github.com/TelepathyIM/telepathy-glib.git",
+                    "tag": "telepathy-glib-0.24.1",
+                    "commit": "c834ef1a50a97cbfae7a0d560ff806fd5aa7ffe8"
+                },
+                {
+                    "type": "patch",
+                    "path": "telepathy-glib-uniquify.patch"
+                }
+            ]
+        },
+        {
+            "name": "sugar-toolkit-gtk3",
+            "no-parallel-make": true,
+            "config-opts": [
+                "--with-python3"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "http://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.116.tar.xz",
+                "sha256": "745a360577efceb10f57ca4cbad5f9ec61f7ed6cc381eeb72422bbd7455b770b"
+            }]
+        },
+        {
+            "name": "sugarapp",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links ${PWD} --install-option=\"--prefix=${FLATPAK_DEST}\" $PWD"
+            ],
+            "sources": [{
+                "type": "git",
+                "url": "https://github.com/tchx84/sugarapp.git",
+                "tag": "v1.5",
+                "commit": "ea6ee3cb3c1289d4112cf5fc6c4db0ab5cd9d8d6"
+            }]
+        },
+        {
+            "name": "mastermind",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=${FLATPAK_DEST} --skip-install-desktop-file --skip-install-mime"
+            ],
+            "sources": [{
+                    "type": "git",
+                    "url": "https://github.com/sugarlabs/mastermind-activity",
+                    "commit": "a55a629181881b64835a26d13a1dae8c9c9507a4"
+                },
+                {
+                    "type": "patch",
+                    "path": "mastermind-port.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "mastermind-monitors.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "mastermind-info.patch"
+                }
+            ],
+            "post-install": [
+                "sugarapp-gen-mimetypes activity/activity.info mimetypes",
+                "sugarapp-gen-appdata activity/activity.info appdata",
+                "sugarapp-gen-desktop activity/activity.info desktop --mimetypes mimetypes",
+                "install -D mimetypes /app/share/mime/packages/org.sugarlabs.MastermindActivity.xml",
+                "install -D mimetypes /app/share/sugar/activities/Mastermind.activity/activity/mimetypes.xml",
+                "install -D appdata /app/share/metainfo/org.sugarlabs.MastermindActivity.appdata.xml",
+                "install -D desktop /app/share/applications/org.sugarlabs.MastermindActivity.desktop",
+                "install -D activity/activity-mastermind.svg /app/share/icons/hicolor/scalable/apps/org.sugarlabs.MastermindActivity.svg"
+            ]
+        }
+    ]
+}

--- a/perl-MakefilePL-Makefile
+++ b/perl-MakefilePL-Makefile
@@ -1,0 +1,5 @@
+all:
+	perl Makefile.PL PREFIX=/app
+
+install:	
+	perl Build install --prefix /app

--- a/telepathy-glib-uniquify.patch
+++ b/telepathy-glib-uniquify.patch
@@ -1,0 +1,25 @@
+From fd733c82ba71201ab7793a38e8fc2fb47a9062f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Florian=20M=C3=BCllner?= <fmuellner@gnome.org>
+Date: Sun, 19 Feb 2017 00:40:05 +0100
+Subject: [PATCH] base-client: Append a single element when uniquifying name
+
+---
+ telepathy-glib/base-client.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/telepathy-glib/base-client.c b/telepathy-glib/base-client.c
+index 600f292..7f5c155 100644
+--- a/telepathy-glib/base-client.c
++++ b/telepathy-glib/base-client.c
+@@ -1347,7 +1347,7 @@ tp_base_client_constructed (GObject *object)
+       unique = tp_escape_as_identifier (tp_dbus_daemon_get_unique_name (
+             self->priv->dbus));
+ 
+-      g_string_append_printf (string, ".%s.n%u", unique, unique_counter++);
++      g_string_append_printf (string, ".%sn%u", unique, unique_counter++);
+       g_free (unique);
+     }
+ 
+-- 
+2.9.3
+


### PR DESCRIPTION
I have tested it in the Abacus Activity, as instructed in the guide.

But I'm having some trouble trying to get the command `flatpak-builder --force-clean --repo=repo build org.sugarlabs.ImplodeActivity.json` to work:

```
patching file activity.py
Hunk #1 FAILED at 26 (different line endings).
Hunk #2 FAILED at 33 (different line endings).
Hunk #3 FAILED at 51 (different line endings).
Hunk #4 FAILED at 66 (different line endings).
Hunk #5 FAILED at 106 (different line endings).
Hunk #6 FAILED at 132 (different line endings).
6 out of 6 hunks FAILED -- saving rejects to file activity.py.rej
Error: module mastermind: Child process exited with code 1
```

I suspected that this is due to the line endings being CRLF, instead of LF, since I developed on Windows and pulled from the VM.

I find it strange because `cat -v <filename.patch>` and `file <filename.patch>` shows that it doesn't use LF line endings. 